### PR TITLE
Updating the base url to load assets on the GitHub Pages instance

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 ######################## default configuration ####################
 # The base URL of your site (required). This will be prepended to all relative URLs.
-baseURL = "/"
+baseURL = "/datahub-home/"
 # Title of your website (required).
 title = "Aurora"
 # Default time zone for time stamps; use any valid tz database name: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List


### PR DESCRIPTION
This pull request includes a small change to the `config/_default/config.toml` file. The change updates the `baseURL` configuration to set the base URL of the site to `/datahub-home/` instead of the root directory (`/`).

This should allow static assets to be properly loaded.