### PR TITLE
Configuring github pages site to SDS GC domain

### DIFF
--- a/.github/workflows/deploy-hugosite.yml
+++ b/.github/workflows/deploy-hugosite.yml
@@ -5,6 +5,9 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+    paths-ignore:
+      - ".*"      # Ignore all dotfiles
+      - "*/.*"    # Ignore all dot directories and their contents
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -56,6 +59,9 @@ jobs:
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Inject Custom Domain
+        run: |
+          echo "sds.canada.ca" > public/CNAME 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+sds.canada.ca

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-sds.canada.ca


### PR DESCRIPTION
This will configure the domain on the github pages side of things.

Configuring github pages site to SDS GC domain.

A domain admin will need to make DNS changes on their end for this to be actioned properly. 

The best way to do this. 
Define the custom domain. 
Make DNS changes
wait for replication 

